### PR TITLE
Added 'Help' button

### DIFF
--- a/help.md
+++ b/help.md
@@ -1,0 +1,44 @@
+##### Special Regex Characters
+* `.`	- matches any character
+* `\d`	- matches digits 0-9
+* `\D`	- matches any character but 0-9
+* `\s`	- matches whitespace characters
+* `\S`	- matches any character but whitespace
+* `\w`	- matches A-Z, a-z, 0-9, and _
+* `\W`	- matches any character but A-Z, a-z, 0-9, and _
+* `\t`	- matches a tab character
+* `\n`	- matches a newline character
+  * This can be used in the template to print a newline
+
+##### Character Sets
+* `[ab]`	- matches any one character within the brackets
+* `[^ab]`	- matches any character except those in the brackets
+
+##### Alternation
+* `a|b`	- matches the expression on the right or the expression on the left
+
+##### Boundaries
+* `^` - matches the beginning of input
+  * Also matches the beginning of the line when 'Multiline' is checked
+* `$` - matches the end of input
+  * Also matches the end of the line before the line break character when 'Multiline' is checked
+* `\b`	- matches word boundaries
+* `\B`	- matches non-word boundaries
+
+##### Grouping and Back References
+* `(a)`	- matches the expression within and remembers the match
+* `\n`	- matches the *n*th parenthesized expression, where *n* is a positive integer
+  * This can be used in the template to print the *n*th parenthesized expression
+*  `(?:a)` - matches the expression within and doesn't remember the match
+
+##### Quantifiers
+* `a*`	- matches the expression 0 or more times
+* `a+`	- matches the expression 1 or more times
+* `a?`	- matches the expression 0 or 1 times
+* `a{n}` - matches the expression *n* times
+* `a{n,}`- matches the expression *n* or more times
+* `a{n,m}` - matches the expression *n* to *m* times
+
+For details, examples, and advanced concepts, visit [this documentation.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Special_characters_meaning_in_regular_expressions)
+
+Note: *a* and *b* in the examples represent any expression

--- a/popup/RegexSearch.html
+++ b/popup/RegexSearch.html
@@ -58,7 +58,7 @@
       </div>
     </div>
 
-    <!-- MODAL -->
+    <!-- SAVE MODAL -->
     <div class="modal fade" id="saveModal" tabindex="-1" role="dialog">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -104,6 +104,24 @@
         </div><!-- /.modal-content -->
       </div><!-- /.modal-dialog -->
     </div><!-- /.modal -->
+    
+    <!-- HELP MODAL -->
+    <div class="modal fade" id="saveModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            
+          </div>
+          <div class="modal-body">
+            
+          </div>
+          <div class="modal-footer">
+            
+          </div>
+        </div><!-- /.modal-content -->
+      </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+          
     <script type="text/javascript" src="RegexSearch.js"></script>
   </body>
 </html>

--- a/popup/RegexSearch.html
+++ b/popup/RegexSearch.html
@@ -56,6 +56,7 @@
       <div class="form-group">
         <button class="btn btn-default btn-block" id="copyResultButton">Copy</button>
       </div>
+      <button class="btn btn-default" id="helpButton" data-toggle="modal" data-target="#helpModal">Help</button>
     </div>
 
     <!-- SAVE MODAL -->
@@ -106,17 +107,82 @@
     </div><!-- /.modal -->
     
     <!-- HELP MODAL -->
-    <div class="modal fade" id="saveModal" tabindex="-1" role="dialog">
+    <div class="modal fade" id="helpModal" tabindex="-1" role="dialog">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
-            
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title">Help</h4>
           </div>
-          <div class="modal-body">
-            
+          <div class="modal-body"> <!--  Converted from help.md -->
+            <h5 id="special-regex-characters">Special Regex Characters</h5>
+            <ul>
+              <li><code>.</code> - matches any character</li>
+              <li><code>\d</code> - matches digits 0-9</li>
+              <li><code>\D</code> - matches any character but 0-9</li>
+              <li><code>\s</code> - matches whitespace characters</li>
+              <li><code>\S</code> - matches any character but whitespace</li>
+              <li><code>\w</code> - matches A-Z, a-z, 0-9, and _</li>
+              <li><code>\W</code> - matches any character but A-Z, a-z, 0-9, and _</li>
+              <li><code>\t</code> - matches a tab character</li>
+              <li><code>\n</code> - matches a newline character
+                <ul>
+                  <li>This can be used in the template to print a newline</li>
+                </ul>
+              </li>
+            </ul>
+            <h5 id="character-sets">Character Sets</h5>
+            <ul>
+              <li><code>[ab]</code> - matches any one character within the brackets</li>
+              <li><code>[^ab]</code> - matches any character except those in the brackets</li>
+            </ul>
+            <h5 id="alternation">Alternation</h5>
+            <ul>
+              <li><code>a|b</code> - matches the expression on the right or the expression on the left</li>
+            </ul>
+            <h5 id="boundaries">Boundaries</h5>
+            <ul>
+              <li><code>^</code> - matches the beginning of input
+                <ul>
+                  <li>Also matches the beginning of the line when &#39;Multiline&#39; is checked</li>
+                </ul>
+              </li>
+              <li><code>$</code> - matches the end of input
+                <ul>
+                  <li>Also matches the end of the line before the line break character when &#39;Multiline&#39; is checked</li>
+                </ul>
+              </li>
+              <li><code>\b</code> - matches word boundaries</li>
+              <li><code>\B</code> - matches non-word boundaries</li>
+            </ul>
+            <h5 id="grouping-and-back-references">Grouping and Back References</h5>
+            <ul>
+              <li><code>(a)</code> - matches the expression within and remembers the match</li>
+              <li><code>\n</code> - matches the <em>n</em>th parenthesized expression, where <em>n</em> is a positive integer
+                <ul>
+                  <li>This can be used in the template to print the <em>n</em>th parenthesized expression</li>
+                </ul>
+              																						</li>
+              <li><code>(?:a)</code> - matches the expression within and doesn&#39;t remember the match</li>
+            </ul>
+            <h5 id="quantifiers">Quantifiers</h5>
+            <ul>
+              <li><code>a*</code> - matches the expression 0 or more times</li>
+              <li><code>a+</code> - matches the expression 1 or more times</li>
+              <li><code>a?</code> - matches the expression 0 or 1 times</li>
+              <li><code>a{n}</code> - matches the expression <em>n</em> times</li>
+              <li><code>a{n,}</code> - matches the expression <em>n</em> or more times</li>
+              <li><code>a{n,m}</code> - matches the expression <em>n</em> to <em>m</em> times</li>
+            </ul>
+            <p>
+              For details, examples, and advanced concepts, visit <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Special_characters_meaning_in_regular_expressions">this documentation.</a>
+            </p>
+            <p class="small">
+              Note: <em>a</em> and <em>b</em> in the examples represent any expression (except in the case of <code>\b</code>)
+            </p>
           </div>
           <div class="modal-footer">
-            
+            <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
           </div>
         </div><!-- /.modal-content -->
       </div><!-- /.modal-dialog -->

--- a/popup/RegexSearch.html
+++ b/popup/RegexSearch.html
@@ -45,7 +45,7 @@
             <li role="separator" class="divider"></li>
           </ul>
         </div>
-      <button class="btn btn-danger" id="resetButton"><span class="glyphicon glyphicon-remove"></span> Reset</button>
+        <button class="btn btn-danger" id="resetButton"><span class="glyphicon glyphicon-remove"></span> Reset</button>
       </div>
       <hr>
       <div class="form-group">
@@ -58,52 +58,52 @@
       </div>
     </div>
 
-  <!-- MODAL -->
-  <div class="modal fade" id="saveModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          <h4 class="modal-title">Save Profile</h4>
-        </div>
-        <div class="modal-body">
-          <div class="alert alert-danger alert-dismissible fade in" style="display:none;" role="alert" id="name_alert_modal">
-            Type A name
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
+    <!-- MODAL -->
+    <div class="modal fade" id="saveModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title">Save Profile</h4>
           </div>
-          <div class="form-group">
-            <label for="profileNameInput_modal">Profile Name</label>
-            <input type="text" class="form-control monospaced" name="profileNameInput_modal" id="profileNameInput_modal" placeholder="Name">
-          </div>
-          <div class="form-group">
-            <label for="regexInput_modal">Type Regex here</label>
-            <div class="input-group">
-              <span class="input-group-addon" id="slash-addon1_modal">/</span>
-              <input type="text" class="form-control monospaced" name="regex" id="regexInput_modal" placeholder="Regular Expression">
-              <span class="input-group-addon" id="slash-addon2_modal">/</span>
+          <div class="modal-body">
+            <div class="alert alert-danger alert-dismissible fade in" style="display:none;" role="alert" id="name_alert_modal">
+              Type A name
+              <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
             </div>
-          </div>
-          <div class="checkbox">
-            <label><input type="checkbox" name="Global_modal" id="globalCheckbox_modal"> Global </label>
-            <label><input type="checkbox" name="Case-insensitive_modal" id="caseInsensitiveCheckbox_modal"> Case-insensitive </label>
-            <label><input type="checkbox" name="Multiline_modal" id="multilineCheckbox_modal"> Multiline </label>
-            <label><input type="checkbox" name="IgnoreHTML_modal" id="IgnoreHTMLCheckbox_modal"> Ignore HTML </label>
-          </div>
-          <div class="form-group">
-            <label for="templateInput_modal">Type a custom template (Optional)</label>
-            <input type="text" class="form-control monospaced" name="template" id="templateInput_modal" placeholder="template">
-          </div>
+            <div class="form-group">
+              <label for="profileNameInput_modal">Profile Name</label>
+              <input type="text" class="form-control monospaced" name="profileNameInput_modal" id="profileNameInput_modal" placeholder="Name">
+            </div>
+            <div class="form-group">
+              <label for="regexInput_modal">Type Regex here</label>
+              <div class="input-group">
+                <span class="input-group-addon" id="slash-addon1_modal">/</span>
+                <input type="text" class="form-control monospaced" name="regex" id="regexInput_modal" placeholder="Regular Expression">
+                <span class="input-group-addon" id="slash-addon2_modal">/</span>
+              </div>
+            </div>
+            <div class="checkbox">
+              <label><input type="checkbox" name="Global_modal" id="globalCheckbox_modal"> Global </label>
+              <label><input type="checkbox" name="Case-insensitive_modal" id="caseInsensitiveCheckbox_modal"> Case-insensitive </label>
+              <label><input type="checkbox" name="Multiline_modal" id="multilineCheckbox_modal"> Multiline </label>
+              <label><input type="checkbox" name="IgnoreHTML_modal" id="IgnoreHTMLCheckbox_modal"> Ignore HTML </label>
+            </div>
+            <div class="form-group">
+              <label for="templateInput_modal">Type a custom template (Optional)</label>
+              <input type="text" class="form-control monospaced" name="template" id="templateInput_modal" placeholder="template">
+            </div>
 
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-          <button type="button" class="btn btn-primary" data-dismiss="modal" id="saveButton_modal">Save changes</button>
-        </div>
-      </div><!-- /.modal-content -->
-    </div><!-- /.modal-dialog -->
-  </div><!-- /.modal -->
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            <button type="button" class="btn btn-primary" data-dismiss="modal" id="saveButton_modal">Save changes</button>
+          </div>
+        </div><!-- /.modal-content -->
+      </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
     <script type="text/javascript" src="RegexSearch.js"></script>
   </body>
 </html>


### PR DESCRIPTION
When I first used the extension, I wasn't completely sure what regex expressions and characters were allowed. When I searched through the code to try to determine what regex you accepted, I noticed that you use the RegExp object.

After reading the MDN documentation for the RegExp object, I created a 'Help' button at the bottom of the extension that pulls up a modal that gives basic information about what you can use and links to the MDN documentation for those that want to find out more or want an example. You can check it out for yourself.

I also fixed a couple indentation problems that I noticed along the way.